### PR TITLE
Prevent crash caused by `decisionHandler` being called twice

### DIFF
--- a/Example Apps/ExampleSwiftApp-iOS/Podfile.lock
+++ b/Example Apps/ExampleSwiftApp-iOS/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WebViewJavascriptBridge (5.1.0)
+  - WebViewJavascriptBridge (6.0.2)
 
 DEPENDENCIES:
   - WebViewJavascriptBridge (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  WebViewJavascriptBridge: 46545f19ee7ccbf7c6b6d60ac32742cb972356a1
+  WebViewJavascriptBridge: 791ee0e26d1bf15efe5fb7fb9666a71a19b89d77
 
 PODFILE CHECKSUM: f657cfcc5a24b7c7f0c7781719b73d4a834bc276
 

--- a/Example Apps/ExampleSwiftApp-iOS/Pods/Local Podspecs/WebViewJavascriptBridge.podspec.json
+++ b/Example Apps/ExampleSwiftApp-iOS/Pods/Local Podspecs/WebViewJavascriptBridge.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "WebViewJavascriptBridge",
-  "version": "5.1.0",
+  "version": "6.0.2",
   "summary": "An iOS & OSX bridge for sending messages between Obj-C/Swift and JavaScript in WKWebViews, UIWebViews & WebViews.",
   "homepage": "https://github.com/marcuswestin/WebViewJavascriptBridge",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/marcuswestin/WebViewJavascriptBridge.git",
-    "tag": "v5.1.0"
+    "tag": "v6.0.2"
   },
   "platforms": {
     "ios": "5.0",

--- a/Example Apps/ExampleSwiftApp-iOS/Pods/Manifest.lock
+++ b/Example Apps/ExampleSwiftApp-iOS/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - WebViewJavascriptBridge (5.1.0)
+  - WebViewJavascriptBridge (6.0.2)
 
 DEPENDENCIES:
   - WebViewJavascriptBridge (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  WebViewJavascriptBridge: 46545f19ee7ccbf7c6b6d60ac32742cb972356a1
+  WebViewJavascriptBridge: 791ee0e26d1bf15efe5fb7fb9666a71a19b89d77
 
 PODFILE CHECKSUM: f657cfcc5a24b7c7f0c7781719b73d4a834bc276
 

--- a/Example Apps/ExampleSwiftApp-iOS/Pods/Target Support Files/WebViewJavascriptBridge/Info.plist
+++ b/Example Apps/ExampleSwiftApp-iOS/Pods/Target Support Files/WebViewJavascriptBridge/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>5.1.0</string>
+  <string>6.0.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ test-travis-ci:
 		-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3'  \
 		-destination 'platform=iOS Simulator,name=iPhone 7,OS=10.1'
 
+test-circle-ci:
+	xcodebuild test -project Tests/WebViewJavascriptBridge.xcodeproj -scheme WebViewJavascriptBridge \
+		-destination 'platform=iOS Simulator,name=iPhone 5s,OS=8.4'  \
+		-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3'   \
+		-destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.1'
+	
+
 publish-pod:
 	# pod trunk register narcvs@gmail.com 'Marcus Westin' --description='MBA/MBP-xyz'
 	# First, bump podspec version, then commit & create tag: `git tag -a "v5.X.Y" -m "Tag v5.X.Y" && git push --tags`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 WebViewJavascriptBridge
 =======================
 
-[![Build Status](https://travis-ci.org/marcuswestin/WebViewJavascriptBridge.svg)](https://travis-ci.org/marcuswestin/WebViewJavascriptBridge)
+[![Circle CI](https://img.shields.io/circleci/project/github/marcuswestin/WebViewJavascriptBridge.svg)](https://circleci.com/gh/marcuswestin/WebViewJavascriptBridge)
 
 An iOS/OSX bridge for sending messages between Obj-C and JavaScript in WKWebViews, UIWebViews & WebViews.
 

--- a/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
+++ b/Tests/WebViewJavascriptBridgeTests/BridgeTests.m
@@ -138,6 +138,23 @@ const NSTimeInterval timeoutSec = 5;
     }];
 }
 
+
+- (void)testJavascriptInvokeUndefinedHandler {
+    [self classSpecificTestJavascriptInvokeUndefinedHandler:_uiWebView];
+    [self classSpecificTestJavascriptInvokeUndefinedHandler:_wkWebView];
+    [self waitForExpectationsWithTimeout:timeoutSec handler:NULL];
+}
+- (void)classSpecificTestJavascriptInvokeUndefinedHandler:(id)webView {
+    WebViewJavascriptBridge *bridge = [self bridgeForWebView:webView];
+    loadEchoSample(webView);
+    XCTestExpectation *callbackInvocked = [self expectationWithDescription:@"Callback invoked"];
+    [bridge callHandler:@"jsInvokeUndefinedHandlerTest" data:nil responseCallback:^(id responseData) {
+        XCTAssertEqualObjects(responseData, @"Response from JS");
+        [callbackInvocked fulfill];
+    }];
+}
+
+
 - (void)testJavascriptReceiveResponseWithoutSafetyTimeout {
     [self classSpecificTestJavascriptReceiveResponseWithoutSafetyTimeout:_uiWebView];
     [self classSpecificTestJavascriptReceiveResponseWithoutSafetyTimeout:_wkWebView];

--- a/Tests/WebViewJavascriptBridgeTests/echo.html
+++ b/Tests/WebViewJavascriptBridgeTests/echo.html
@@ -27,6 +27,15 @@
 				}
 			})
 		})
+        bridge.registerHandler('jsInvokeUndefinedHandlerTest', function(data, responseCallback) {
+            bridge.callHandler('undefinedHandler', { foo:'bar' }, function(response) {
+                if (response && Object.keys(response).length == 0) {
+                    responseCallback("Response from JS")
+                } else {
+                    responseCallback("Failed")
+                }
+            })
+        })
 	})
 	</script>
 </body></html>

--- a/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
+++ b/WebViewJavascriptBridge/WKWebViewJavascriptBridge.m
@@ -147,6 +147,7 @@
             [_base logUnkownMessage:url];
         }
         decisionHandler(WKNavigationActionPolicyCancel);
+        return;
     }
     
     if (strongDelegate && [strongDelegate respondsToSelector:@selector(webView:decidePolicyForNavigationAction:decisionHandler:)]) {

--- a/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
+++ b/WebViewJavascriptBridge/WebViewJavascriptBridgeBase.m
@@ -102,6 +102,7 @@ static int logMaxLength = 500;
             
             if (!handler) {
                 NSLog(@"WVJBNoHandlerException, No handler for message from JS: %@", message);
+                responseCallback(@{});
                 continue;
             }
             

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+machine:
+  xcode:
+    version: 8.2
+# dependencies:
+#   override:
+#     - brew install kylef/formulae/swiftenv
+#     - swiftenv install 3.0
+test:
+  override:
+    - make test-circle-ci


### PR DESCRIPTION
## Before your create your PR:

#### Please add tests for any new or changed functionality!

1. Edit `Tests/WebViewJavascriptBridgeTests/BridgeTests.m`
2. Create a new test which demostrates your changes.
3. Run `make test` and make sure your test is passing
4. That's it!

#### Thanks for improving WebViewJavascriptBridge!

Cheers,
@marcuswestin
